### PR TITLE
feat: return 404 on missing campaign and unauthorised campaign

### DIFF
--- a/src/pages/campaigns.tsx
+++ b/src/pages/campaigns.tsx
@@ -1,2 +1,5 @@
-export { requireLogin as getServerSideProps } from "shared";
+import { requireLogin } from "shared";
+
 export { Campaigns as default } from "../campaigns";
+
+export const getServerSideProps = requireLogin();

--- a/src/pages/campaigns/[campaignId].tsx
+++ b/src/pages/campaigns/[campaignId].tsx
@@ -1,2 +1,41 @@
+import { graphUrl } from "api/config";
+import { FetchCampaign, FetchCampaignVariables } from "campaign/gql";
+import request, { gql } from "graphql-request";
+import { requireLogin } from "shared";
+
 export { Campaign as default } from "campaign";
-export { requireLogin as getServerSideProps } from "shared";
+
+export const getServerSideProps = requireLogin(async (ctx, { userId }) => {
+  const data = await request<FetchCampaign, FetchCampaignVariables>(
+    graphUrl,
+    gql`
+      query FetchCampaign($id: ID!) {
+        campaign(campaignId: $id) {
+          __typename
+          ... on Campaign {
+            id
+          }
+          ... on CampaignNotFound {
+            message
+          }
+        }
+      }
+    `,
+    { id: ctx.query.campaignId as string },
+    {
+      "bag-user-id": userId,
+    }
+  );
+
+  if (!data || data.campaign.__typename === "CampaignNotFound") {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      campaign: data.campaign,
+    },
+  };
+});

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,2 +1,11 @@
+import { requireLogin } from "shared";
+
 export { Profile as default } from "profile/Profile";
-export { requireLogin as getServerSideProps } from "shared";
+
+export const getServerSideProps = requireLogin((_, session) => {
+  return {
+    props: {
+      session,
+    },
+  };
+});

--- a/src/shared/redirect.ts
+++ b/src/shared/redirect.ts
@@ -1,25 +1,38 @@
-import { GetServerSideProps } from "next";
+import {
+  GetServerSideProps,
+  GetServerSidePropsContext,
+  GetServerSidePropsResult,
+} from "next";
 import absolute from "next-absolute-url";
-import { getSession } from "./session";
+import { getSession, SessionWithID } from "./session";
 
-export const requireLogin: GetServerSideProps = async (ctx) => {
-  const session = await getSession(ctx);
+export const requireLogin = (
+  gssp?: (
+    // eslint-disable-next-line no-unused-vars
+    context: GetServerSidePropsContext,
+    // eslint-disable-next-line no-unused-vars
+    session: SessionWithID
+  ) => GetServerSidePropsResult<any> | Promise<GetServerSidePropsResult<any>>
+) => {
+  return async (ctx: GetServerSidePropsContext) => {
+    const session = await getSession(ctx);
 
-  if (!session.userId) {
-    const { req, resolvedUrl } = ctx;
-    const { origin } = absolute(req);
+    if (!session.userId) {
+      const { req, resolvedUrl } = ctx;
+      const { origin } = absolute(req);
 
-    const callbackUrl = `${origin}${resolvedUrl}`;
+      const callbackUrl = `${origin}${resolvedUrl}`;
 
-    return {
-      redirect: {
-        destination: `/login?callbackUrl=${callbackUrl}`,
-        permanent: false,
-      },
-    };
-  }
+      return {
+        redirect: {
+          destination: `/login?callbackUrl=${callbackUrl}`,
+          permanent: false,
+        },
+      };
+    }
 
-  return { props: { session } };
+    return gssp ? gssp(ctx, session) : { props: {} };
+  };
 };
 
 export const provideSession: GetServerSideProps = async (ctx) => {

--- a/src/shared/session.ts
+++ b/src/shared/session.ts
@@ -1,10 +1,15 @@
+import { Session } from "next-auth";
 import {
   getSession as nextGetSession,
   GetSessionOptions,
   useSession as useNextSession,
 } from "next-auth/client";
 
-export const getSession = async (options?: GetSessionOptions | undefined) => {
+export type SessionWithID = Session & { userId: string };
+
+export const getSession = async (
+  options?: GetSessionOptions | undefined
+): Promise<SessionWithID> => {
   if (process.env.NEXT_PUBLIC_SKIP_SESSION) {
     return {
       user: {


### PR DESCRIPTION
change requireLogin to higher-order function that wraps other SSR functions

There's an opportunity here to pass the whole campaign object as pageprops but I don't know to make that play nicely with the useQuery hook.

This change also gives a 404 if you try to access a campaign you aren't assigned to :) 

closes #65 